### PR TITLE
Fix version file URL Property

### DIFF
--- a/GAP-for-JNSQ.version
+++ b/GAP-for-JNSQ.version
@@ -1,26 +1,26 @@
 {
-     "NAME":"Contract Pack: GAP for JNSQ",
-	 "URL":"https://github.com/InfiNoctis/GAP-for-JNSQ",
-	 "DOWNLOAD":"https://github.com/InfiNoctis/GAP-for-JNSQ/releases",
-     "CHANGE_LOG_URL":"https://github.com/InfiNoctis/GAP-for-JNSQ/blob/main/CHANGELOG.txt",
-     "GITHUB":{
-         "USERNAME":"InfiNoctis",
-         "REPOSITORY":"GAP-for-JNSQ",
+    "NAME":"Contract Pack: GAP for JNSQ",
+    "URL":"https://github.com/InfiNoctis/GAP-for-JNSQ/raw/main/GAP-for-JNSQ.version",
+    "DOWNLOAD":"https://github.com/InfiNoctis/GAP-for-JNSQ/releases",
+    "CHANGE_LOG_URL":"https://github.com/InfiNoctis/GAP-for-JNSQ/blob/main/CHANGELOG.txt",
+    "GITHUB":{
+        "USERNAME":"InfiNoctis",
+        "REPOSITORY":"GAP-for-JNSQ",
      },
      "VERSION":{
-         "MAJOR":1,
-         "MINOR":0,
-         "PATCH":1,
-         "BUILD":0
+        "MAJOR":1,
+        "MINOR":0,
+        "PATCH":1,
+        "BUILD":0
      },
      "KSP_VERSION":{
-         "MAJOR":1,
-         "MINOR":10,
-         "PATCH":1
+        "MAJOR":1,
+        "MINOR":10,
+        "PATCH":1
      },
      "KSP_VERSION_MIN":{
-         "MAJOR":1,
-         "MINOR":8,
-         "PATCH":1
+        "MAJOR":1,
+        "MINOR":8,
+        "PATCH":1
      }
  } 


### PR DESCRIPTION
The URL property of a version file is supposed to point to an online copy _of the version file itself_, so you can make post-release updates to the compatibility as needed. But currently it's just set to the base repo.

- http://ksp.cybutek.net/kspavc/Documents/README.htm

> URL - Optional
> Location of a remote **version file** for update checking.

Now it's fixed. Noticed while reviewing KSP-CKAN/NetKAN#8241.

Tagging @InfiNoctis because otherwise GitHub often doesn't notify for pull requests.